### PR TITLE
Correct invalid keywords.txt KEYWORD_TOKENTYPE

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,8 +13,8 @@ getPressureScale	KEYWORD2
 getTemperatureScale	KEYWORD2
 
 #Constants
-Address1	CONSTANT1
-Address2	CONSTANT1
-Address3	CONSTANT1
-MassFlow	CONSTANT1
-DiffPressure	CONSTANT1
+Address1	LITERAL1
+Address2	LITERAL1
+Address3	LITERAL1
+MassFlow	LITERAL1
+DiffPressure	LITERAL1


### PR DESCRIPTION
Use of an invalid KEYWORD_TOKENTYPE value in keywords.txt causes the keyword to be colored by the default editor.function.style (as used by KEYWORD2, KEYWORD3, LITERAL2) in Arduino IDE 1.6.5 and newer. On Arduino IDE 1.6.4 and older this will cause the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype